### PR TITLE
Fixed some Compilation Erros

### DIFF
--- a/ArduinoSNMP.cpp
+++ b/ArduinoSNMP.cpp
@@ -402,7 +402,9 @@ uint32_t SNMPClass::sendTrapv1(SNMP_PDU *pdu, SNMP_TRAP_TYPES trap_type, int16_t
   _packetPos += value.size;
   
   //Time Ticks
-  value.encode(SNMP_SYNTAX_TIME_TICKS, millis()/10, _packet + _packetPos);
+  //Similar error as previous commit in ArduinoSNMP.h.
+  //value.encode(SNMP_SYNTAX_TIME_TICKS, millis() / 10, _packet + _packetPos);
+  value.encode(SNMP_SYNTAX_TIME_TICKS, (const uint64_t)millis()/10, _packet + _packetPos);
   _packetPos +=6;//syntax + length + 4 octets
 
   //unknown

--- a/ArduinoSNMP.h
+++ b/ArduinoSNMP.h
@@ -966,7 +966,10 @@ typedef struct SNMP_PDU {
     t_v->OID.clear();
     t_v->clear();
     t_v->OID.fromString("1.3.6.1.2.1.1.3.0");//OID of the value type being sent
-    t_v->encode(SNMP_SYNTAX_TIME_TICKS, millis()/10);
+    //This line below causes error, millis() type doesn't have a definite type. 
+    //This produces different candidates for one overloaded function call.
+    //t_v->encode(SNMP_SYNTAX_TIME_TICKS, millis()/10);
+    t_v->encode(SNMP_SYNTAX_TIME_TICKS, (const uint16_t)millis()/10);
     value.size = add_data_private(t_v);
     
     //SNMPv2 trapOID


### PR DESCRIPTION
I encountered this issue while compiling the library alongside an empty code. I'm compiling on esp8266 core version 2.4.2 on Visual Studio (vMicro) based on Arduino IDE version 1.4/1.6.

There are two similar issues in `ArduinoSNMP.cpp` and `ArduinoSNMP.h` files. They originate from the fact that some compilers might fail to specify the exact type of what the `millis()` function returns. So casting it to the `const uint64_t` seem to fix the issue. 

I also didn't have knowledge/time to cast it to some platform independent type. So I decided to cast it to the demanding type of the `encode` function.